### PR TITLE
Add `allow_abbrev=False` to ArgumentParser for stricter argument parsing

### DIFF
--- a/casaconfig/private/get_argparser.py
+++ b/casaconfig/private/get_argparser.py
@@ -21,7 +21,7 @@ def get_argparser(add_help=False):
     import argparse as __argparse
 
     ## look for arguments affecting the configuration
-    parser = __argparse.ArgumentParser(add_help=add_help)
+    parser = __argparse.ArgumentParser(add_help=add_help, allow_abbrev=False)
     parser.add_argument( "--configfile",dest='configfile', default='~/.casa/config.py',
                          help='path to the user configuration file')
     parser.add_argument( "--noconfig", dest='noconfig', action='store_const', const=True, default=False,


### PR DESCRIPTION
Hi @bgarwood, I have a library written to take a `--config xyz.yaml` CLI option for configuration, but that led to an ambiguous situation as the parser from `casaconfig` thought it was a match to --configfile -- a prefix matching is done by default currently.

This PR is intended to avoid this specific situation. However, I don't know if this restriction will have repercussions on other use cases, so please just take this as a proposal for further consideration. Thanks!